### PR TITLE
Drive pipeline model lists from models.yaml

### DIFF
--- a/datasets/field-guidance/run_pipeline_eval.py
+++ b/datasets/field-guidance/run_pipeline_eval.py
@@ -541,31 +541,28 @@ def _get_sweep_configs() -> list[tuple[str, str | None, str]]:
 
     configs: list[tuple[str, str | None, str]] = []
 
-    # GCP models via pipeline backend
-    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or os.environ.get("VERTEX_PROJECT_ID"):
-        from nmdc_metadata_suggestor_ai_tool.llm_client import GEMINI_MODELS
+    # Read all model lists from a single config file.
+    models_yaml = HERE.parent / "models.yaml"
+    models_cfg = {}
+    if models_yaml.exists():
+        with open(models_yaml) as f:
+            models_cfg = yaml.safe_load(f) or {}
 
-        for m in GEMINI_MODELS:
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or os.environ.get("VERTEX_PROJECT_ID"):
+        for m in models_cfg.get("gcp_models", []):
             configs.append(("pipeline", "gcp", m))
 
-    # PNNL models via pipeline backend
     if os.environ.get("AI_INCUBATOR_KEY") and os.environ.get("AI_INCUBATOR_BASE_URL"):
-        from nmdc_metadata_suggestor_ai_tool.llm_client import PNNL_GPT_MODELS
-
-        for m in PNNL_GPT_MODELS:
+        for m in models_cfg.get("pnnl_models", []):
             configs.append(("pipeline", "pnnl", m))
 
     # llm library models (personal API keys)
-    models_yaml = HERE.parent / "models.yaml"
-    if models_yaml.exists():
-        with open(models_yaml) as f:
-            model_names = yaml.safe_load(f).get("models", [])
-        for name in model_names:
-            try:
-                llm_lib.get_model(name)
-                configs.append(("llm", None, name))
-            except llm_lib.UnknownModelError:
-                pass  # skip models without keys/plugins
+    for name in models_cfg.get("models", []):
+        try:
+            llm_lib.get_model(name)
+            configs.append(("llm", None, name))
+        except llm_lib.UnknownModelError:
+            pass  # skip models without keys/plugins
 
     return configs
 

--- a/datasets/models.yaml
+++ b/datasets/models.yaml
@@ -5,6 +5,11 @@
 #   Auth: keys in llm key store (`uv run llm keys set <provider>`) or env vars.
 #   To add a model: add it here and run `just generate`.
 #
+# `gcp_models:` / `pnnl_models:` — pipeline-backend models swept by
+#   `run_pipeline_eval.py --sweep`.  The suggestor's LLMClient passes model
+#   names straight through to the SDK, so any valid Vertex AI or PNNL model
+#   name works here.  Add new models to these lists (no code change needed).
+#
 # `tiers:` — model selections for `just full-eval`. Each tier has cheap/mid/top
 #   models per provider. These WILL change as providers release new models —
 #   update when a provider's flagship or budget model changes.
@@ -20,6 +25,22 @@ models:
   - anthropic/claude-sonnet-4-6
   - anthropic/claude-haiku-4-5-20251001
   - gemini/gemini-2.5-flash
+
+# Pipeline-backend model lists.  The suggestor's LLMClient passes model names
+# straight through to the underlying SDK with no validation, so any valid
+# Vertex AI or PNNL model name works here.  Previously these were imported
+# from the suggestor's hardcoded GEMINI_MODELS / PNNL_GPT_MODELS constants.
+gcp_models:
+  - gemini-2.5-pro
+  - gemini-2.5-flash
+
+pnnl_models:
+  - gpt-5-project
+  - gpt-5.1-project
+  - gpt-5.2-project
+  - gpt-4.1-project
+  - o3-project
+  - o4-mini-project
 
 # Model tiers for full eval runs (`just full-eval --cheap|--full`).
 # Update as providers release new models. These WILL change over time.

--- a/tests/test_suggestor_import.py
+++ b/tests/test_suggestor_import.py
@@ -52,10 +52,28 @@ def test_metadata_field_suggestion_model() -> None:
     assert suggestion.value != ""
 
 
-def test_llm_client_accepts_arbitrary_model() -> None:
-    """LLMClient passes model names through without validation."""
-    client = LLMClient(access_provider="gcp", model="gemini-99-ultra")
-    assert client.model == "gemini-99-ultra"
+def test_llm_client_accepts_arbitrary_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLMClient passes model names through without enum/whitelist validation.
+
+    Uses the ``pnnl`` access_provider rather than ``gcp`` so this test runs
+    in CI without Google credentials. ``LLMClient.__init__`` for ``gcp``
+    eagerly calls ``google.auth.default()`` which fails in credential-less
+    environments; ``pnnl`` just reads env vars and constructs an ``OpenAI``
+    client (no network call on init). The point being verified — that the
+    model string is stored as-is — is provider-independent.
+    """
+    # Suggestor v1.1 captures AI_INCUBATOR_KEY and BASE_URL at module import
+    # time, so monkeypatch.setenv alone doesn't help once the module is loaded.
+    # Patch both the module-level constants and the env vars for compatibility
+    # with future suggestor versions that read env vars inside __init__.
+    from nmdc_metadata_suggestor_ai_tool import llm_client as llm_client_module
+
+    monkeypatch.setenv("AI_INCUBATOR_KEY", "test-key")
+    monkeypatch.setenv("AI_INCUBATOR_BASE_URL", "https://example.invalid")
+    monkeypatch.setattr(llm_client_module, "AI_INCUBATOR_KEY", "test-key", raising=False)
+    monkeypatch.setattr(llm_client_module, "BASE_URL", "https://example.invalid", raising=False)
+    client = LLMClient(access_provider="pnnl", model="any-weird-name")
+    assert client.model == "any-weird-name"
 
 
 def test_schema_context_builder_exists() -> None:

--- a/tests/test_suggestor_import.py
+++ b/tests/test_suggestor_import.py
@@ -9,9 +9,6 @@ import inspect
 
 import pytest
 from nmdc_metadata_suggestor_ai_tool.llm_client import (
-    DEFAULT_GEMINI_MODEL,
-    GEMINI_MODELS,
-    PNNL_GPT_MODELS,
     LLMClient,
 )
 from nmdc_metadata_suggestor_ai_tool.models.llm_output import (
@@ -55,15 +52,10 @@ def test_metadata_field_suggestion_model() -> None:
     assert suggestion.value != ""
 
 
-def test_gemini_models_available() -> None:
-    """At least one Gemini model is configured."""
-    assert len(GEMINI_MODELS) > 0
-    assert DEFAULT_GEMINI_MODEL in GEMINI_MODELS
-
-
-def test_pnnl_models_available() -> None:
-    """PNNL model list is populated."""
-    assert len(PNNL_GPT_MODELS) > 0
+def test_llm_client_accepts_arbitrary_model() -> None:
+    """LLMClient passes model names through without validation."""
+    client = LLMClient(access_provider="gcp", model="gemini-99-ultra")
+    assert client.model == "gemini-99-ultra"
 
 
 def test_schema_context_builder_exists() -> None:


### PR DESCRIPTION
## Summary
- The suggestor's `LLMClient` passes model names straight through to the SDK with no validation — any valid Vertex AI or PNNL model name works
- Moved GCP and PNNL model lists from the suggestor's hardcoded `GEMINI_MODELS` / `PNNL_GPT_MODELS` constants into `datasets/models.yaml` (`gcp_models` / `pnnl_models` keys)
- New models can now be added with a one-line YAML change instead of a suggestor release

## Test plan
- [x] All 158 tests pass
- [x] New test verifies `LLMClient` accepts arbitrary model names
- [ ] Verify `--sweep` still discovers GCP/PNNL models when credentials are configured

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)