### PR TITLE
Adopt grouped dependabot + auto-merge policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+    # One grouped PR per week instead of one per Action. Minor/patch
+    # bumps auto-merge via .github/workflows/dependabot-automerge.yml
+    # when CI passes; majors stay in their own PR for human review.
+    groups:
+      actions-minor:
+        update-types:
+          - minor
+          - patch
     open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merge dependabot PRs for minor/patch bumps when CI passes.
+# Majors (breaking) still require manual review.
+#
+# Requires:
+#   - Branch protection on `main` with "Require status checks to pass
+#     before merging" enabled. Without that, --auto just merges
+#     immediately which defeats the point.
+#   - "Allow auto-merge" enabled in repo settings (Settings ->
+#     General -> Pull Requests).
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for non-major bumps
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/uv-upgrade.yml
+++ b/.github/workflows/uv-upgrade.yml
@@ -21,6 +21,7 @@ jobs:
         run: uv lock --upgrade
 
       - name: Open PR if lockfile changed
+        id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: uv lock --upgrade"
@@ -28,8 +29,16 @@ jobs:
           delete-branch: true
           title: "chore: weekly dependency upgrade"
           body: |
-            Automated weekly `uv lock --upgrade`.
+            Automated weekly `uv lock --upgrade`. Auto-merges when CI
+            passes (branch protection catches any regression).
 
             Check the Security tab after merging — Dependabot alerts for packages
             bumped here will auto-close once the new versions land on main.
           labels: dependencies
+
+      - name: Enable auto-merge on the PR
+        if: steps.create-pr.outputs.pull-request-number
+        run: gh pr merge --auto --squash "$PR_NUM"
+        env:
+          PR_NUM: ${{ steps.create-pr.outputs.pull-request-number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #65.

## Summary

- Group minor/patch GH Action bumps into one weekly PR (dependabot.yml)
- Auto-merge dependabot PRs on CI green, majors excluded (new workflow)
- Auto-merge the weekly uv-upgrade PR too (existing workflow extended)

## Why

#50-54 had to be closed manually as stale. Rather than do that again every month, automate the happy path and keep manual review for real risk (major bumps, changes CI can't catch).

## Required repo settings

Both are clicks in GitHub UI, one-time:

- Settings → General → Pull Requests → ✅ Allow auto-merge
- Settings → Branches → Branch protection on `main` → Require status checks to pass

Without branch protection, `--auto` merges immediately (defeats the point). Please verify before merging this PR.

## Test plan

- [x] pre-commit passes locally (all non-CI checks green)
- [ ] Verify repo auto-merge setting is on
- [ ] Verify branch protection requires CI
- [ ] Watch next Monday's uv-upgrade PR — should open and auto-merge if lockfile changes + CI green
- [ ] Watch next week's dependabot PR (if any Actions have bumps) — should open grouped and auto-merge

## Broader scope

Policy documented for org-wide adoption at `~/Desktop/markdown/dependabot-policy-across-repos-2026-04-20.md`. Natural upstream home: `ai4curation/github-ai-integrations` Copier template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)