### PR TITLE
Warn when simple_question metric active without pinned scorer model

### DIFF
--- a/src/nmdc_ai_eval/run_suite.py
+++ b/src/nmdc_ai_eval/run_suite.py
@@ -181,6 +181,21 @@ def main(suite_path: Path, output_dir: Path | None = None) -> None:
     n_total = n_cases * n_models
     click.echo(f"Running {n_cases} cases × {n_models} models = {n_total} calls (~{n_total * 3}–{n_total * 5}s)")
 
+    # Warn when simple_question is active and no scorer model is pinned.
+    # simple_question makes a second LLM call per result using llm's default
+    # model (currently gpt-4o per llm_matrix/metrics.py:DEFAULT_EVALUATION_MODEL_NAME).
+    # That default is implicit and can change. Env-triad suites bypass this via
+    # _env_triad_score(); other suites should pin --scorer-model for reproducibility.
+    uses_simple_question = any("simple_question" in (t.metrics or []) for t in (suite.templates or {}).values())
+    scorer_model_env = __import__("os").environ.get("LLM_SCORER_MODEL")
+    if uses_simple_question and not scorer_model_env:
+        click.echo(
+            "  Note: suite uses simple_question metric. Scorer model is llm's default "
+            "(currently gpt-4o). Pin it with --scorer-model or LLM_SCORER_MODEL env var "
+            "for reproducible scoring across runs.",
+            err=True,
+        )
+
     # Open llm logs DB for inline token/timing capture
     logs_db = _open_llm_logs_db()
     last_rowid = _get_max_rowid(logs_db) if logs_db else 0


### PR DESCRIPTION
Closes #73.

## Why

`simple_question` makes a second LLM call per result using llm-matrix's default evaluation model (`gpt-4o`, hardcoded in `llm_matrix/metrics.py:DEFAULT_EVALUATION_MODEL_NAME`). That default is implicit — nothing in the run output tells you which model is scoring, and it can change between llm-matrix versions.

## What

Startup warning to stderr when:
- The suite template uses `simple_question`
- `LLM_SCORER_MODEL` env var is not set

Points at `--scorer-model` / `LLM_SCORER_MODEL` as the fix.

## Scope

Env-triad suites are exempt: #72 bypasses `simple_question` entirely for env-triad via `_env_triad_score`. This PR covers other suites (`ebs`, `sampledata`, `field-guidance`) that still use `simple_question`.

## Test plan

- [x] `just check` green
- [ ] Reviewer runs `just run-ebs` or `just run-sampledata` and confirms the warning appears in stderr
- [ ] Verify warning disappears when `LLM_SCORER_MODEL=gpt-4o-mini just run-ebs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)