### PR TITLE
Add llm plugin for Vertex AI (vertex/gemini-* and vertex/claude-*)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -59,7 +59,7 @@ uv run llm keys path                # path to the JSON file
 
 **CBORG** fronts OpenAI, Anthropic, and Gemini model families through one OpenAI-compatible endpoint. It is *not* currently wired into `llm-matrix`; `just verify-auth` checks CBORG with a direct `openai` SDK call against `CBORG_BASE_URL`. Evals that want to use CBORG need a dedicated code path (see issue #62).
 
-**Vertex** models are now reachable from `llm-matrix` via the in-repo `llm_plugin_vertex` — use `vertex/gemini-*` or `vertex/claude-*` anywhere a model name is accepted. Auth reuses the existing `GOOGLE_APPLICATION_CREDENTIALS` + `VERTEX_PROJECT_ID` setup below.
+**Vertex** models are now reachable from `llm-matrix` via the in-repo `llm_plugin_vertex` — use `vertex/gemini-*` or `vertex/claude-*` anywhere a model name is accepted. Auth reuses the existing `GOOGLE_APPLICATION_CREDENTIALS` + `VERTEX_PROJECT_ID` setup below. Region defaults to `us-east5`; override with `CLOUD_ML_REGION` (or `GEMINI_REGION`) if your project uses a different Vertex location.
 
 ## Direct LLM APIs (personal keys)
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -52,12 +52,14 @@ uv run llm keys path                # path to the JSON file
 | `gpt-*` | `llm` built-in openai plugin | OpenAI direct |
 | `anthropic/*` | `llm-claude-3` plugin | Anthropic direct |
 | `gemini/*` | `llm-gemini` plugin | Google **AI Studio** (not Vertex) |
+| `vertex/gemini-*` | local `llm_plugin_vertex` | **Vertex AI** (Gemini via generateContent) |
+| `vertex/claude-*` | local `llm_plugin_vertex` | **Vertex AI** (Claude via rawPredict) |
 | `*-project` suffix | Pipeline backend | PNNL AI Incubator |
-| (Vertex / CBORG) | Not via `llm-matrix` — see notes below | |
+| (CBORG) | Not via `llm-matrix` — see notes below | |
 
 **CBORG** fronts OpenAI, Anthropic, and Gemini model families through one OpenAI-compatible endpoint. It is *not* currently wired into `llm-matrix`; `just verify-auth` checks CBORG with a direct `openai` SDK call against `CBORG_BASE_URL`. Evals that want to use CBORG need a dedicated code path (see issue #62).
 
-**Vertex** is Google-only (Gemini natively, Anthropic-on-Vertex via the anthropic SDK). It powers the production suggestor pipeline but is not a drop-in `llm-matrix` target.
+**Vertex** models are now reachable from `llm-matrix` via the in-repo `llm_plugin_vertex` — use `vertex/gemini-*` or `vertex/claude-*` anywhere a model name is accepted. Auth reuses the existing `GOOGLE_APPLICATION_CREDENTIALS` + `VERTEX_PROJECT_ID` setup below.
 
 ## Direct LLM APIs (personal keys)
 
@@ -96,9 +98,9 @@ Note: no `/v1` suffix — the OpenAI SDK appends the path automatically.
 
 The `llm-gemini` plugin only supports [Google AI Studio](https://aistudio.google.com/) API keys. It does **not** support Vertex AI authentication.
 
-The suggestor tool uses Vertex AI via Sierra Moxon's `nmdc-llm` service account. Those credentials work with the **pipeline backend** (`--provider gcp`) but not with the **llm backend** or `llm-matrix` suites.
+For Vertex-backed Gemini (and Claude) via `llm` / `llm-matrix`, use the in-repo `llm_plugin_vertex` with model names like `vertex/gemini-2.5-flash` or `vertex/claude-haiku-4-5`. See the [Vertex AI section below](#vertex-ai-gcp).
 
-For Gemini with the `llm` backend: generate a free Google AI Studio key at <https://aistudio.google.com/apikey> and run `uv run llm keys set gemini`. The free tier provides 1,500 requests/day — sufficient for eval runs.
+For Gemini with the `llm` backend (AI Studio, not Vertex): generate a free Google AI Studio key at <https://aistudio.google.com/apikey> and run `uv run llm keys set gemini`. The free tier provides 1,500 requests/day — sufficient for eval runs.
 
 ## Vertex AI (GCP)
 
@@ -125,7 +127,7 @@ However, Vertex exposes each publisher through a **different API endpoint**:
 
 The suggestor's `LLMClient(access_provider="gcp")` currently only dispatches via `generateContent` (see [`llm_client.py:229`](https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/blob/main/src/nmdc_metadata_suggestor_ai_tool/llm_client.py#L229)), which means Gemini works but Claude calls return `400 "not supported in the generateContent API"` even though the project has Claude enabled. This is a **dispatcher gap, not an access restriction.**
 
-Run `just probe-vertex-garden` to see the current picture for your SA. The probe routes Anthropic candidates through `AnthropicVertex` directly as a workaround until the suggestor grows a `gcp-anthropic` access provider. See [issue #46](https://github.com/microbiomedata/nmdc-ai-eval/issues/46) for status.
+The in-repo `llm_plugin_vertex` routes each publisher through the correct SDK, so `vertex/gemini-*` and `vertex/claude-*` both work from `llm-matrix` eval suites. Run `just probe-vertex-garden` to see which specific model names the SA can reach on your project.
 
 > **Budget reminder:** The `nmdc-llm` GCP project has a shared $500 total budget. Claude Opus is ~$15/$75 per 1M tokens — use it sparingly. Prefer personal or CBORG keys for iterative dev.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,14 @@ markers = ["api: tests requiring LLM API calls (excluded from CI)"]
 
 [tool.coverage.run]
 omit = [
-  "src/nmdc_ai_eval/run_suite.py",          # API-only; untestable without live LLM calls
-  "src/nmdc_ai_eval/llm_plugin_vertex.py",  # execute() methods require live Vertex SA creds
+  "src/nmdc_ai_eval/run_suite.py",  # API-only; untestable without live LLM calls
+]
+
+[tool.coverage.report]
+exclude_lines = [
+  # Vertex plugin execute() methods require live SA creds — excluded by pattern,
+  # not whole-file, so register_models() and _get_vertex_project() stay covered.
+  "^\\s*def execute\\(",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dev = [
   "types-pyyaml>=6.0.12.20250915",
 ]
 
+[project.entry-points."llm"]
+vertex = "nmdc_ai_eval.llm_plugin_vertex"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/nmdc_ai_eval"]
 
@@ -74,7 +77,8 @@ markers = ["api: tests requiring LLM API calls (excluded from CI)"]
 
 [tool.coverage.run]
 omit = [
-  "src/nmdc_ai_eval/run_suite.py",    # API-only; untestable without live LLM calls
+  "src/nmdc_ai_eval/run_suite.py",          # API-only; untestable without live LLM calls
+  "src/nmdc_ai_eval/llm_plugin_vertex.py",  # execute() methods require live Vertex SA creds
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "oaklib>=0.6.0",
   "openai>=1.0",
   "pandas>=2.0",
+  "pydantic>=2.0",
   "python-dotenv>=1.0",
   "pyyaml>=6.0",
 ]

--- a/src/nmdc_ai_eval/llm_plugin_vertex.py
+++ b/src/nmdc_ai_eval/llm_plugin_vertex.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Iterator
 
 import llm
 from dotenv import load_dotenv
+from pydantic import Field
 
 if TYPE_CHECKING:
     from llm import Conversation, Prompt, Response
@@ -49,6 +50,18 @@ load_dotenv()
 _DEFAULT_VERTEX_REGION = os.environ.get("CLOUD_ML_REGION", os.environ.get("GEMINI_REGION", "us-east5"))
 _VERTEX_PROJECT_ID = os.environ.get("VERTEX_PROJECT_ID")
 _CREDS_FILE = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+
+class _VertexOptions(llm.Options):
+    """Shared options for Vertex models.
+
+    Declared so llm-matrix (and other callers) can pass ``temperature``
+    without pydantic rejecting it as an extra input. Keep this minimal —
+    add options only when a caller actually needs to set them.
+    """
+
+    temperature: float | None = Field(default=None, ge=0.0, le=2.0)
+    max_tokens: int | None = Field(default=None, ge=1)
 
 
 def _get_vertex_project() -> str:
@@ -61,6 +74,7 @@ class VertexGeminiModel(llm.Model):
     """Gemini model on Vertex AI via google.genai (generateContent endpoint)."""
 
     needs_key = None  # auth via service-account file, not API key
+    Options = _VertexOptions  # type: ignore[assignment]
 
     def __init__(self, model_id: str, vertex_model_name: str) -> None:
         self.model_id = model_id
@@ -122,6 +136,7 @@ class VertexClaudeModel(llm.Model):
     """Claude model on Vertex AI via AnthropicVertex (rawPredict endpoint)."""
 
     needs_key = None  # auth via service-account file, not API key
+    Options = _VertexOptions  # type: ignore[assignment]
 
     def __init__(self, model_id: str, vertex_model_name: str) -> None:
         self.model_id = model_id

--- a/src/nmdc_ai_eval/llm_plugin_vertex.py
+++ b/src/nmdc_ai_eval/llm_plugin_vertex.py
@@ -1,0 +1,191 @@
+"""llm plugin for Vertex AI models (Gemini and Claude).
+
+Registers ``vertex/gemini-*`` and ``vertex/claude-*`` model IDs so they can be
+used anywhere llm models are accepted — including llm-matrix suite evals.
+
+Auth: reads ``GOOGLE_APPLICATION_CREDENTIALS`` and ``VERTEX_PROJECT_ID`` from
+the environment (loaded from ``.env`` by dotenv). The same SA and project ID
+used by ``just verify-auth`` work here.
+
+Dispatch:
+  vertex/gemini-* → google.genai.Client(vertexai=True).models.generate_content
+  vertex/claude-* → anthropic.AnthropicVertex.messages.create
+
+These correspond to the two Vertex API endpoints (:generateContent for Gemini,
+:rawPredict / :streamRawPredict for Claude). They cannot be swapped — Gemini
+names will fail through the Anthropic path and vice versa.
+
+Model names: use bare Vertex model IDs (e.g. ``gemini-2.5-flash``,
+``claude-haiku-4-5``, ``claude-sonnet-4-5@20250929``). The ``vertex/`` prefix
+is stripped before dispatch. See ``probe_vertex_garden.py`` to discover which
+names are reachable on your project.
+
+Usage in a suite YAML matrix:
+    model:
+      - vertex/gemini-2.5-flash
+      - vertex/claude-haiku-4-5
+
+Usage in pilot command:
+    just pilot-env-triad 5 "vertex/gemini-2.5-flash,vertex/claude-haiku-4-5"
+
+Note: this plugin is loaded via llm's local plugin mechanism. It is registered
+in pyproject.toml under [project.entry-points."llm"] — no separate install
+step needed beyond ``uv sync``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Iterator
+
+import llm
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from llm import Conversation, Prompt, Response
+
+load_dotenv()
+
+_DEFAULT_VERTEX_REGION = os.environ.get("CLOUD_ML_REGION", os.environ.get("GEMINI_REGION", "us-east5"))
+_VERTEX_PROJECT_ID = os.environ.get("VERTEX_PROJECT_ID")
+_CREDS_FILE = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
+
+def _get_vertex_project() -> str:
+    if _VERTEX_PROJECT_ID:
+        return _VERTEX_PROJECT_ID
+    raise ValueError("VERTEX_PROJECT_ID is not set. Add it to your .env file. See docs/auth.md for setup instructions.")
+
+
+class VertexGeminiModel(llm.Model):
+    """Gemini model on Vertex AI via google.genai (generateContent endpoint)."""
+
+    needs_key = None  # auth via service-account file, not API key
+
+    def __init__(self, model_id: str, vertex_model_name: str) -> None:
+        self.model_id = model_id
+        self.vertex_model_name = vertex_model_name
+
+    def execute(
+        self,
+        prompt: "Prompt",
+        stream: bool,
+        response: "Response",
+        conversation: "Conversation | None",
+    ) -> Iterator[str]:
+        from google import genai
+        from google.genai import types as genai_types
+        from google.oauth2 import service_account
+
+        project = _get_vertex_project()
+        scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+        if _CREDS_FILE:
+            credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
+                _CREDS_FILE, scopes=scopes
+            )
+        else:
+            import google.auth
+
+            credentials, _ = google.auth.default(scopes=scopes)
+
+        client = genai.Client(
+            vertexai=True,
+            project=project,
+            location=_DEFAULT_VERTEX_REGION,
+            credentials=credentials,
+        )
+        system = prompt.system or ""
+        user_text = prompt.prompt or ""
+        max_tokens = getattr(getattr(prompt, "options", None), "max_tokens", None) or 4096
+        temperature = getattr(getattr(prompt, "options", None), "temperature", None)
+        config = genai_types.GenerateContentConfig(
+            max_output_tokens=max_tokens,
+            temperature=temperature,
+            system_instruction=system if system else None,
+        )
+        api_response = client.models.generate_content(
+            model=self.vertex_model_name,
+            contents=user_text,
+            config=config,
+        )
+        text = api_response.text or ""
+        yield text
+        usage = getattr(api_response, "usage_metadata", None)
+        if usage:
+            response.set_usage(
+                input=getattr(usage, "prompt_token_count", None),
+                output=getattr(usage, "candidates_token_count", None),
+            )
+
+
+class VertexClaudeModel(llm.Model):
+    """Claude model on Vertex AI via AnthropicVertex (rawPredict endpoint)."""
+
+    needs_key = None  # auth via service-account file, not API key
+
+    def __init__(self, model_id: str, vertex_model_name: str) -> None:
+        self.model_id = model_id
+        self.vertex_model_name = vertex_model_name
+
+    def execute(
+        self,
+        prompt: "Prompt",
+        stream: bool,
+        response: "Response",
+        conversation: "Conversation | None",
+    ) -> Iterator[str]:
+        from anthropic import AnthropicVertex
+
+        project = _get_vertex_project()
+        client = AnthropicVertex(region=_DEFAULT_VERTEX_REGION, project_id=project)
+        system = prompt.system or ""
+        user_text = prompt.prompt or ""
+        max_tokens = getattr(getattr(prompt, "options", None), "max_tokens", None) or 4096
+        messages = [{"role": "user", "content": user_text}]
+        kwargs: dict[str, object] = {
+            "model": self.vertex_model_name,
+            "max_tokens": max_tokens,
+            "messages": messages,
+        }
+        if system:
+            kwargs["system"] = system
+        temperature = getattr(getattr(prompt, "options", None), "temperature", None)
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+
+        message = client.messages.create(**kwargs)  # type: ignore[call-overload]
+        text = "".join(block.text for block in message.content if hasattr(block, "text"))
+        yield text
+        if message.usage:
+            response.set_usage(
+                input=message.usage.input_tokens,
+                output=message.usage.output_tokens,
+            )
+
+
+# Models to register. Add more as needed — run `just probe-vertex-garden`
+# to discover which names are currently reachable on your project.
+_GEMINI_MODELS = [
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-2.0-flash",
+]
+
+_CLAUDE_MODELS = [
+    "claude-haiku-4-5",
+    "claude-sonnet-4-5@20250929",
+    "claude-opus-4-1@20250514",
+]
+
+
+@llm.hookimpl
+def register_models(register: object) -> None:
+    # llm passes a callable as `register`; the type stub says `object` so
+    # we use cast to satisfy mypy without a bare ignore.
+    from typing import Any, Callable, cast
+
+    _reg: Callable[..., Any] = cast(Callable[..., Any], register)
+    for name in _GEMINI_MODELS:
+        _reg(VertexGeminiModel(f"vertex/{name}", name))
+    for name in _CLAUDE_MODELS:
+        _reg(VertexClaudeModel(f"vertex/{name}", name))

--- a/tests/test_vertex_plugin.py
+++ b/tests/test_vertex_plugin.py
@@ -10,18 +10,21 @@ import pytest
 
 
 def test_vertex_gemini_models_registered() -> None:
-    """All expected vertex/gemini-* models appear in llm model list."""
+    """Every name in _GEMINI_MODELS is registered as vertex/<name>."""
+    from nmdc_ai_eval.llm_plugin_vertex import _GEMINI_MODELS
+
     model_ids = {m.model_id for m in llm.get_models()}
-    assert "vertex/gemini-2.5-flash" in model_ids
-    assert "vertex/gemini-2.5-pro" in model_ids
-    assert "vertex/gemini-2.0-flash" in model_ids
+    for name in _GEMINI_MODELS:
+        assert f"vertex/{name}" in model_ids
 
 
 def test_vertex_claude_models_registered() -> None:
-    """All expected vertex/claude-* models appear in llm model list."""
+    """Every name in _CLAUDE_MODELS is registered as vertex/<name>."""
+    from nmdc_ai_eval.llm_plugin_vertex import _CLAUDE_MODELS
+
     model_ids = {m.model_id for m in llm.get_models()}
-    assert "vertex/claude-haiku-4-5" in model_ids
-    assert "vertex/claude-sonnet-4-5@20250929" in model_ids
+    for name in _CLAUDE_MODELS:
+        assert f"vertex/{name}" in model_ids
 
 
 def test_vertex_model_ids_have_vertex_prefix() -> None:

--- a/tests/test_vertex_plugin.py
+++ b/tests/test_vertex_plugin.py
@@ -1,0 +1,65 @@
+"""Tests for the Vertex AI llm plugin (llm_plugin_vertex.py).
+
+These tests verify model registration and configuration — they do NOT
+make real Vertex API calls (those are integration tests that require SA
+credentials and are excluded from CI).
+"""
+
+import llm
+import pytest
+
+
+def test_vertex_gemini_models_registered() -> None:
+    """All expected vertex/gemini-* models appear in llm model list."""
+    model_ids = {m.model_id for m in llm.get_models()}
+    assert "vertex/gemini-2.5-flash" in model_ids
+    assert "vertex/gemini-2.5-pro" in model_ids
+    assert "vertex/gemini-2.0-flash" in model_ids
+
+
+def test_vertex_claude_models_registered() -> None:
+    """All expected vertex/claude-* models appear in llm model list."""
+    model_ids = {m.model_id for m in llm.get_models()}
+    assert "vertex/claude-haiku-4-5" in model_ids
+    assert "vertex/claude-sonnet-4-5@20250929" in model_ids
+
+
+def test_vertex_model_ids_have_vertex_prefix() -> None:
+    """No vertex model is accidentally registered without the prefix."""
+    from nmdc_ai_eval.llm_plugin_vertex import _CLAUDE_MODELS, _GEMINI_MODELS, VertexClaudeModel, VertexGeminiModel
+
+    for name in _GEMINI_MODELS:
+        m = VertexGeminiModel(f"vertex/{name}", name)
+        assert m.model_id.startswith("vertex/")
+        assert m.vertex_model_name == name
+
+    for name in _CLAUDE_MODELS:
+        m = VertexClaudeModel(f"vertex/{name}", name)
+        assert m.model_id.startswith("vertex/")
+        assert m.vertex_model_name == name
+
+
+def test_vertex_models_retrievable_via_llm_get_model() -> None:
+    """llm.get_model() resolves vertex/ model IDs without error."""
+    m = llm.get_model("vertex/gemini-2.5-flash")
+    assert m.model_id == "vertex/gemini-2.5-flash"
+
+    m2 = llm.get_model("vertex/claude-haiku-4-5")
+    assert m2.model_id == "vertex/claude-haiku-4-5"
+
+
+def test_vertex_project_id_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_get_vertex_project() raises ValueError when VERTEX_PROJECT_ID unset."""
+    import nmdc_ai_eval.llm_plugin_vertex as plugin
+    from nmdc_ai_eval.llm_plugin_vertex import _get_vertex_project
+
+    # _VERTEX_PROJECT_ID is captured at module import time; patch the module-level var.
+    monkeypatch.setattr(plugin, "_VERTEX_PROJECT_ID", None)
+    with pytest.raises(ValueError, match="VERTEX_PROJECT_ID"):
+        _get_vertex_project()
+
+
+def test_vertex_unknown_model_raises() -> None:
+    """llm.get_model() raises UnknownModelError for unregistered vertex names."""
+    with pytest.raises(llm.UnknownModelError):
+        llm.get_model("vertex/gpt-4o")  # OpenAI is not on Vertex Model Garden

--- a/tests/test_vertex_plugin.py
+++ b/tests/test_vertex_plugin.py
@@ -63,3 +63,18 @@ def test_vertex_unknown_model_raises() -> None:
     """llm.get_model() raises UnknownModelError for unregistered vertex names."""
     with pytest.raises(llm.UnknownModelError):
         llm.get_model("vertex/gpt-4o")  # OpenAI is not on Vertex Model Garden
+
+
+def test_vertex_options_accept_temperature() -> None:
+    """Vertex models accept temperature=0.0 without pydantic rejecting it.
+
+    Regression: llm-matrix passes temperature through Options; earlier
+    the Options class inherited llm.Options with no temperature field
+    and raised `extra_forbidden`, aborting every eval call.
+    """
+    gemini = llm.get_model("vertex/gemini-2.5-flash")
+    claude = llm.get_model("vertex/claude-haiku-4-5")
+    # Each model's Options class must parse temperature without error.
+    assert gemini.Options(temperature=0.0).temperature == 0.0
+    assert claude.Options(temperature=0.7).temperature == 0.7
+    assert gemini.Options(max_tokens=100).max_tokens == 100

--- a/uv.lock
+++ b/uv.lock
@@ -1916,6 +1916,7 @@ dependencies = [
     { name = "oaklib" },
     { name = "openai" },
     { name = "pandas" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
 ]
@@ -1947,6 +1948,7 @@ requires-dist = [
     { name = "oaklib", specifier = ">=0.6.0" },
     { name = "openai", specifier = ">=1.0" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]


### PR DESCRIPTION
## Why

`just run-env-triad` and other llm-matrix suites couldn't reach Vertex models — `llm-gemini` only talks to AI Studio, `llm-claude-3` only talks to Anthropic direct. That blocked cross-provider comparisons that include Vertex (e.g. "Gemini-via-Vertex vs Gemini-via-AI-Studio" or "Claude-on-Vertex vs Anthropic-direct").

This plugin closes that gap without a new runner. Existing Vertex auth (`GOOGLE_APPLICATION_CREDENTIALS` + `VERTEX_PROJECT_ID`) is reused; no new creds.

## What's here

- `src/nmdc_ai_eval/llm_plugin_vertex.py` — registers `vertex/gemini-*` (via `google.genai`) and `vertex/claude-*` (via `AnthropicVertex`)
- `tests/test_vertex_plugin.py` — 6 registration/resolution tests (no live API calls)
- `pyproject.toml` — entry-point wiring + coverage exclusion for `execute()` methods (live creds required)
- `docs/auth.md` — routing table and Vertex section updated

## Verified

- 182/182 tests pass, all pre-commit hooks pass
- `uv run llm models | grep vertex` shows all 6 registered models
- Live smoke tested `vertex/gemini-2.5-flash` and `vertex/claude-haiku-4-5` via the SA

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)