### PR TITLE
Make dependency audit a scheduled/on-demand job, not a PR gate

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,20 @@
+name: Dependency audit
+
+on:
+  schedule:
+    - cron: "0 13 * * 1"   # Mondays 13:00 UTC
+  workflow_dispatch:        # on-demand from the Actions tab
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Install dependencies
+        run: uv sync --dev
+      - name: pip-audit
+        run: uv run pip-audit --ignore-vuln CVE-2025-69872 --ignore-vuln CVE-2026-4539

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,8 +53,3 @@ repos:
         entry: uv run pytest -q -m "not api" --cov=nmdc_ai_eval --cov-fail-under=90 --no-cov-on-fail
         language: system
         pass_filenames: false
-      - id: pip-audit
-        name: pip-audit
-        entry: uv run pip-audit --ignore-vuln CVE-2025-69872 --ignore-vuln CVE-2026-4539
-        language: system
-        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Follow the [Quickstart in README](README.md#quickstart) to clone the repo, insta
 
 ## Pre-commit hooks explained
 
-Pre-commit hooks are automated checks that run every time you `git commit`. If any check fails, the commit is blocked until you fix the issue. This repo uses them to catch lint errors, type problems, test failures, and dependency vulnerabilities before code reaches a PR.
+Pre-commit hooks are automated checks that run every time you `git commit`. If any check fails, the commit is blocked until you fix the issue. This repo uses them to catch lint errors, type problems, and test failures before code reaches a PR. Dependency vulnerability scanning is *not* a pre-commit hook (so an upstream advisory never blocks an unrelated PR); run it with `just audit` — see below.
 
 Every `git commit` runs the full suite of checks automatically. You can also run them manually:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,14 @@ The hooks and what they enforce are documented in the [QC and automation table i
   ideal: "some expected output"
 ```
 
-**pip-audit** (CVEs) — A transitive dependency has a known vulnerability. Update it:
+**pip-audit** (CVEs, run via `just audit` or the weekly CI audit, not as part of `just check`) — A transitive dependency has a known vulnerability. Update it:
 
 ```bash
 uv lock --upgrade-package <package-name>
 uv sync
 ```
 
-Then re-run `just check` to confirm the CVE is resolved.
+Then re-run `just audit` to confirm the CVE is resolved.
 
 **ruff / ruff-format** — Usually auto-fixed by `just fix`. If the error persists after that, read the rule code in the output (e.g. `E501`, `I001`) and fix manually.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Model names must match `uv run llm models list`. `just test` verifies every mode
 
 ## QC and automation
 
-All checks are defined once in `.pre-commit-config.yaml`. The justfile and CI both delegate to pre-commit so there is a single source of truth.
+All PR-gating checks are defined once in `.pre-commit-config.yaml`. The justfile and CI both delegate to pre-commit so there is a single source of truth. Dependency vulnerability scanning is intentionally not one of these checks; it runs separately via `just audit` (see below).
 
 | Check | `just all` | git commit | git push | CI (PR) |
 |---|---|---|---|---|

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ All checks are defined once in `.pre-commit-config.yaml`. The justfile and CI bo
 | mypy | yes | yes | yes | yes |
 | deptry | yes | yes | yes | yes |
 | pytest (excludes `@api`) | yes | yes | yes | yes |
-| pip-audit | yes | yes | yes | yes |
+
+Dependency vulnerability scanning (`pip-audit`) runs separately from the commit/PR gates so an upstream advisory never blocks unrelated work: on demand via `just audit`, and weekly in CI (`.github/workflows/pip-audit.yml`, also runnable on demand from the Actions tab).
 
 The minimum coverage threshold is **90%** (enforced via `--cov-fail-under` in pre-commit). `run_suite.py` is excluded from measurement because it requires live LLM calls. `llm_adapter.py` is tested with mocked LLM calls.
 

--- a/justfile
+++ b/justfile
@@ -24,6 +24,10 @@ test:
 coverage:
     uv run pytest -m "not api" --cov=nmdc_ai_eval --cov-report=term-missing
 
+# Audit installed deps for known vulnerabilities (advisory; also runs weekly in CI)
+audit:
+    uv run pip-audit --ignore-vuln CVE-2025-69872 --ignore-vuln CVE-2026-4539
+
 # Verify API auth works for all providers (1 cheap call each)
 verify-auth:
     uv run python scripts/verify_auth.py


### PR DESCRIPTION
Implements the non-blocking dependency-audit pattern: catch known-vulnerable deps without letting an upstream advisory's *timing* block unrelated PRs.

- `pip-audit` is removed from the blocking pre-commit suite, so it no longer fails `just check` / the CI "Run all checks" step.
- It's now reachable three ways, all running the identical command: `just audit` (local), a weekly scheduled workflow, and that workflow's on-demand `workflow_dispatch` trigger (Actions tab "Run workflow").
- Dependabot (with auto-merge) stays the proactive fixer; this audit is the backstop.
- PRs continue to gate on lint / type / test / coverage.
- Docs (README QC table, CONTRIBUTING failure guide) updated to match.

The `--ignore-vuln` list is preserved unchanged from the previous hook.

Companion org-wide convention proposal: filed at https://github.com/microbiomedata/issues/issues/1744
