### PR TITLE
test: presence-check suggestor suggestion model fields

### DIFF
--- a/tests/test_suggestor_import.py
+++ b/tests/test_suggestor_import.py
@@ -41,7 +41,10 @@ def test_llm_output_model() -> None:
 def test_metadata_field_suggestion_model() -> None:
     """MetadataFieldSuggestion has field_name, reason, and value."""
     fields = set(MetadataFieldSuggestion.model_fields.keys())
-    assert fields == {"field_name", "reason", "value"}
+    # Presence check, not exact match: the suggestor model gains fields over
+    # time (e.g. the optional `id` added in 1.2.0 for sample-level suggestions),
+    # and this proof-of-life test should not break on benign upstream additions.
+    assert {"field_name", "reason", "value"} <= fields
 
     suggestion = MetadataFieldSuggestion(
         field_name="env_broad_scale",


### PR DESCRIPTION
`test_metadata_field_suggestion_model` asserted the suggestor's `MetadataFieldSuggestion` had exactly `{field_name, reason, value}`. nmdc-metadata-suggestor-ai-tool 1.2.0 added an optional `id` field (for sample-level suggestions, https://github.com/microbiomedata/nmdc-metadata-suggestor-ai-tool/pull/84), so the exact-set check now fails and blocks the weekly dependency-upgrade PR https://github.com/microbiomedata/nmdc-ai-eval/pull/81.

This is a proof-of-life import test. A presence check (`{...} <= fields`) is the right contract: the suggestor model is expected to grow fields, and this test should only confirm the three the eval depends on are present.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>